### PR TITLE
Use sys.argv instead of argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ vagrant up
 Following is a list of environment variables used by vagrant when provisioning the SDE.
 
 * SDK_FILE_NAME: Name of the self-exctracting SDK package to install into the SDE. Can include wildcards.
-Defaults to `oecore*toolchain*sh`.
+Defaults to `oecore*toolchain*sh`. Note that this has to be an SDK with Qt on
+it.
 * NO_GUI: Will create a headless SDE when set.
 
 

--- a/sde-cookbook/qtcreator/configure-qtcreator.py
+++ b/sde-cookbook/qtcreator/configure-qtcreator.py
@@ -20,8 +20,7 @@ been sourced before this script is executed.
 import os
 import shutil
 import time
-import argparse
-
+import sys
 
 class CommandException(Exception):
     pass
@@ -135,11 +134,11 @@ class QtCreatorBootstrapper(object):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("sdktool_path", help="The path to sdktool")
-    args = parser.parse_args()
+    if len(sys.argv) != 2:
+        print("Need to pass path to the sdktool")
+        quit()
 
-    bootstrapper = QtCreatorBootstrapper(args.sdktool_path)
+    bootstrapper = QtCreatorBootstrapper(sys.argv[1])
     try:
         bootstrapper.add_cxx_toolchain()
         bootstrapper.add_cc_toolchain()


### PR DESCRIPTION
The PELUX SDKs do not ship the argparse module for python3, which causes
the provisioning of the SDE to fail. Since there are no positional
arguments but only one, required, argument on the command line, we can
parse it with argv instead.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>