### PR TITLE
test_sdk_installation: Reduce code duplication

### DIFF
--- a/test/test_sdk_installation.py
+++ b/test/test_sdk_installation.py
@@ -48,24 +48,25 @@ def pipe_to_str(pipe):
     return "\n".join([ x.decode() for x in pipe.readlines() ])
 
 
+# Fixtures common code
+
+def setup_sdk_stub_in_vm(stub_script_name):
+    try:
+        assert os.system("SDK_FILE_NAME=\"test/stubs/{}\" NO_GUI=1 vagrant up".format(stub_script_name)) == 0
+        yield
+    finally:
+        os.system("vagrant destroy -f")
+
 # Fixtures
 
 @pytest.fixture(scope="class")
 def vagrant():
-    try:
-        assert os.system("SDK_FILE_NAME=\"test/stubs/full_sdk.sh\" NO_GUI=1 vagrant up") == 0
-        yield
-    finally:
-        os.system("vagrant destroy -f")
-
+    setup_sdk_stub_in_vm("full_sdk.sh")
 
 @pytest.fixture(scope="class")
 def vagrant_no_qt():
-    try:
-        assert os.system("SDK_FILE_NAME=\"test/stubs/sans_qmake_sdk.sh\" NO_GUI=1 vagrant up") == 0
-        yield
-    finally:
-        os.system("vagrant destroy -f")
+    setup_sdk_stub_in_vm("sans_qmake_sdk.sh")
+
 
 # Tests
 


### PR DESCRIPTION
I suppose this is the solution to issue #6 

I think the duplication is very minor since there are only two tests, but in any case:

Counting non-comment lines:
7+7 lines per test was reduced to 3+3 for each, but then 6 of those lines of course reappear in the new common function.  So in total a reduction of 2 lines ;-)

Of course it's still clearer now, and as additional tests are written the gain can be larger over time.
