### PR TITLE
tests: use python3

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -12,4 +12,4 @@
 
 cd "$(dirname "$0")"
 
-py.test -v --junit-xml=test_result.xml
+py.test-3 -v --junit-xml=test_result.xml

--- a/test/scripts/base/can_find_sdk.py
+++ b/test/scripts/base/can_find_sdk.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Pelagicore AB
+# Copyright (C) 2018 Luoxft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/scripts/base/check_is_ubuntu.py
+++ b/test/scripts/base/check_is_ubuntu.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Pelagicore AB
+# Copyright (C) 2018 Luxoft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/scripts/base/qtcreator_is_configured_to_use_sdk.py
+++ b/test/scripts/base/qtcreator_is_configured_to_use_sdk.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Pelagicore AB
+# Copyright (C) 2018 Luxoft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/scripts/qt/qtcreator_is_configured_to_use_sdk_with_qt.py
+++ b/test/scripts/qt/qtcreator_is_configured_to_use_sdk_with_qt.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Pelagicore AB
+# Copyright (C) 2018 Luxoft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_sdk_installation.py
+++ b/test/test_sdk_installation.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
 #
 # Copyright (C) 2017 Pelagicore AB
+# Copyright (C) 2018 Luxoft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Currently tests use mixed syntax from Python 2 and Python 3, which
breaks of them. Explicitly run all the tests using Python 3 to avoid
those problems.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>