### PR TITLE
Vagrantfile: make apt always use default answer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 #
 # Copyright (C) 2017 Pelagicore AB
-# Copyright (C) 2018 Luxoft Sweden AB
+# Copyright (C) 2018-2019 Luxoft Sweden AB
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 def install_with_apt(config, program)
   config.vm.provision "shell" do |s|
-    s.inline = "apt-get update -y && apt-get install " + program + " -y"
+    s.inline = "apt-get update -y && yes \"\" | apt-get install " + program + " -y"
   end
 end
 


### PR DESCRIPTION
Occasionally, apt-get will ask a user a question, e.g. whether should
it keep old configuration file for a package or install a new default
one.

Since the installation process should be fully automatic, we make it
always go with the default options by emulation ENTER key press with
yes tool.

Fixes #29 

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>