### PR TITLE
Vagrantfile: lock Ubuntu box revision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ end
 
 def setup_virtualbox_provider(config, num_cpus, ram_mb, vram_mb)
   config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box_version = "201906.18.0"
   config.vm.box_check_update = false
 
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
We seem to have some new issues with building VM after every update of
the inherited Vagrant box, bento/ubuntu-18.04.

Lock revision for now.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>