### PR TITLE
README: specify pytest-3 as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ it.
 Testing
 -------
 Dependencies:
-* pytest
+* pytest-3
 
 Note: In order to do clean tests, this script will tear down and destroy the VM if it is already created
 ```bash


### PR DESCRIPTION
Tests were moved to Python 3 in @2cdcacee5bad54c.

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>